### PR TITLE
Rename tests to match use-cases

### DIFF
--- a/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed/EssentialFeed.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		1E2B585D26831BB60083BB41 /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC6F685267B34D500BD5175 /* XCTestCase+MemoryLeakTracking.swift */; };
 		1E65085D268DA09300B5BB21 /* ImageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E65085C268DA09300B5BB21 /* ImageItem.swift */; };
 		1E65085F268DA0D400B5BB21 /* FeedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E65085E268DA0D400B5BB21 /* FeedImage.swift */; };
-		1E6F11152647D917005F9F2B /* RemoteFeedLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E6F11142647D917005F9F2B /* RemoteFeedLoaderTests.swift */; };
+		1E6F11152647D917005F9F2B /* LoadFeedFromRemoteUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E6F11142647D917005F9F2B /* LoadFeedFromRemoteUseCaseTests.swift */; };
 		1E7733E726733A1800277C35 /* URLSessionHTTPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E7733E626733A1800277C35 /* URLSessionHTTPClientTests.swift */; };
 		1E89FB8C266A788A00B1421B /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E89FB8B266A788A00B1421B /* HTTPClient.swift */; };
 		1E89FB8E266A795A00B1421B /* FeedItemMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E89FB8D266A795A00B1421B /* FeedItemMapper.swift */; };
@@ -47,7 +47,7 @@
 		1E2B5856268319690083BB41 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1E65085C268DA09300B5BB21 /* ImageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageItem.swift; sourceTree = "<group>"; };
 		1E65085E268DA0D400B5BB21 /* FeedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImage.swift; sourceTree = "<group>"; };
-		1E6F11142647D917005F9F2B /* RemoteFeedLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeedLoaderTests.swift; sourceTree = "<group>"; };
+		1E6F11142647D917005F9F2B /* LoadFeedFromRemoteUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedFromRemoteUseCaseTests.swift; sourceTree = "<group>"; };
 		1E7733E626733A1800277C35 /* URLSessionHTTPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionHTTPClientTests.swift; sourceTree = "<group>"; };
 		1E89FB8B266A788A00B1421B /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		1E89FB8D266A795A00B1421B /* FeedItemMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedItemMapper.swift; sourceTree = "<group>"; };
@@ -101,7 +101,7 @@
 		1E42A7E7266C2784008D57F1 /* Feed API */ = {
 			isa = PBXGroup;
 			children = (
-				1E6F11142647D917005F9F2B /* RemoteFeedLoaderTests.swift */,
+				1E6F11142647D917005F9F2B /* LoadFeedFromRemoteUseCaseTests.swift */,
 				1E7733E626733A1800277C35 /* URLSessionHTTPClientTests.swift */,
 				1EC6F684267B349C00BD5175 /* Helper */,
 			);
@@ -339,7 +339,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1E6F11152647D917005F9F2B /* RemoteFeedLoaderTests.swift in Sources */,
+				1E6F11152647D917005F9F2B /* LoadFeedFromRemoteUseCaseTests.swift in Sources */,
 				1E7733E726733A1800277C35 /* URLSessionHTTPClientTests.swift in Sources */,
 				1EC6F686267B34D500BD5175 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);

--- a/EssentialFeed/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
+++ b/EssentialFeed/EssentialFeedTests/Feed API/LoadFeedFromRemoteUseCaseTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 import EssentialFeed
 
-final class RemoteFeedLoaderTests: XCTestCase {
+final class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 
     func test_init_doesNotRequestDataFromClient() {
         let url: URL = .given


### PR DESCRIPTION
Rename tests to (LoodFeedFromRemote) use case

Signed-off-by: Ahmad Atef <ahmad.atef.ali.ahmad@gmail.com>